### PR TITLE
Refine scoping of existing commands.

### DIFF
--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -43,7 +43,7 @@ public class LogicManager implements Logic {
         logger.info("----------------[USER COMMAND][" + commandText + "]");
 
         CommandResult commandResult;
-        Command command = mainCatalogueParser.parseCommand(commandText, Status.CATALOGUE);
+        Command command = mainCatalogueParser.parseCommand(commandText, model.getStatus());
         commandResult = command.execute(model);
 
         try {

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -43,7 +43,7 @@ public class LogicManager implements Logic {
         logger.info("----------------[USER COMMAND][" + commandText + "]");
 
         CommandResult commandResult;
-        Command command = mainCatalogueParser.parseCommand(commandText);
+        Command command = mainCatalogueParser.parseCommand(commandText, Status.CATALOGUE);
         commandResult = command.execute(model);
 
         try {

--- a/src/main/java/seedu/address/logic/parser/MainCatalogueParser.java
+++ b/src/main/java/seedu/address/logic/parser/MainCatalogueParser.java
@@ -75,6 +75,8 @@ public class MainCatalogueParser {
                 return new HelpCommand();
 
             case StartCommand.COMMAND_WORD:
+                return new StartCommandParser().parse(arguments);
+
             case LeaveCommand.COMMAND_WORD:
                 throw new InvalidScopeException(Status.PROJECT, Status.CATALOGUE);
 
@@ -83,9 +85,6 @@ public class MainCatalogueParser {
             }
         } else if (status == Status.PROJECT) {
             switch (commandWord) {
-
-            case StartCommand.COMMAND_WORD:
-                return new StartCommandParser().parse(arguments);
 
             case LeaveCommand.COMMAND_WORD:
                 return new LeaveCommand();
@@ -102,6 +101,7 @@ public class MainCatalogueParser {
             case ClearCommand.COMMAND_WORD:
             case FindCommand.COMMAND_WORD:
             case ListCommand.COMMAND_WORD:
+            case StartCommand.COMMAND_WORD:
                 throw new InvalidScopeException(Status.CATALOGUE, Status.PROJECT);
 
             default:

--- a/src/main/java/seedu/address/logic/parser/MainCatalogueParser.java
+++ b/src/main/java/seedu/address/logic/parser/MainCatalogueParser.java
@@ -50,61 +50,62 @@ public class MainCatalogueParser {
         if (status == Status.CATALOGUE) {
             switch (commandWord) {
 
-                case AddCommand.COMMAND_WORD:
-                    return new AddCommandParser().parse(arguments);
+            case AddCommand.COMMAND_WORD:
+                return new AddCommandParser().parse(arguments);
 
-                case EditCommand.COMMAND_WORD:
-                    return new EditCommandParser().parse(arguments);
+            case EditCommand.COMMAND_WORD:
+                return new EditCommandParser().parse(arguments);
 
-                case DeleteCommand.COMMAND_WORD:
-                    return new DeleteCommandParser().parse(arguments);
+            case DeleteCommand.COMMAND_WORD:
+                return new DeleteCommandParser().parse(arguments);
 
-                case ClearCommand.COMMAND_WORD:
-                    return new ClearCommand();
+            case ClearCommand.COMMAND_WORD:
+                return new ClearCommand();
 
-                case FindCommand.COMMAND_WORD:
-                    return new FindCommandParser().parse(arguments);
+            case FindCommand.COMMAND_WORD:
+                return new FindCommandParser().parse(arguments);
 
-                case ListCommand.COMMAND_WORD:
-                    return new ListCommand();
+            case ListCommand.COMMAND_WORD:
+                return new ListCommand();
 
-                case ExitCommand.COMMAND_WORD:
-                    return new ExitCommand();
+            case ExitCommand.COMMAND_WORD:
+                return new ExitCommand();
 
-                case HelpCommand.COMMAND_WORD:
-                    return new HelpCommand();
+            case HelpCommand.COMMAND_WORD:
+                return new HelpCommand();
 
-                case StartCommand.COMMAND_WORD:
-                case LeaveCommand.COMMAND_WORD:
-                    throw new InvalidScopeException(Status.PROJECT, Status.CATALOGUE);
+            case StartCommand.COMMAND_WORD:
+            case LeaveCommand.COMMAND_WORD:
+                throw new InvalidScopeException(Status.PROJECT, Status.CATALOGUE);
 
-                default:
-                    throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
+            default:
+                throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
             }
         } else if (status == Status.PROJECT) {
             switch (commandWord) {
-                case StartCommand.COMMAND_WORD:
-                    return new StartCommandParser().parse(arguments);
 
-                case LeaveCommand.COMMAND_WORD:
-                    return new LeaveCommand();
+            case StartCommand.COMMAND_WORD:
+                return new StartCommandParser().parse(arguments);
 
-                case ExitCommand.COMMAND_WORD:
-                    return new ExitCommand();
+            case LeaveCommand.COMMAND_WORD:
+                return new LeaveCommand();
 
-                case HelpCommand.COMMAND_WORD:
-                    return new HelpCommand();
+            case ExitCommand.COMMAND_WORD:
+                return new ExitCommand();
 
-                case AddCommand.COMMAND_WORD:
-                case EditCommand.COMMAND_WORD:
-                case DeleteCommand.COMMAND_WORD:
-                case ClearCommand.COMMAND_WORD:
-                case FindCommand.COMMAND_WORD:
-                case ListCommand.COMMAND_WORD:
-                    throw new InvalidScopeException(Status.CATALOGUE, Status.PROJECT);
+            case HelpCommand.COMMAND_WORD:
+                return new HelpCommand();
 
-                default:
-                    throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
+            case AddCommand.COMMAND_WORD:
+            case EditCommand.COMMAND_WORD:
+            case DeleteCommand.COMMAND_WORD:
+            case ClearCommand.COMMAND_WORD:
+            case FindCommand.COMMAND_WORD:
+            case ListCommand.COMMAND_WORD:
+                throw new InvalidScopeException(Status.CATALOGUE, Status.PROJECT);
+
+            default:
+                throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
             }
         } else {
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/MainCatalogueParser.java
+++ b/src/main/java/seedu/address/logic/parser/MainCatalogueParser.java
@@ -18,6 +18,7 @@ import seedu.address.logic.commands.LeaveCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.StartCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.project.Status;
 
 /**
  * Parses user input.
@@ -33,10 +34,11 @@ public class MainCatalogueParser {
      * Parses user input into command for execution.
      *
      * @param userInput full user input string
+     * @param status the status of the current scoping
      * @return the command based on the user input
      * @throws ParseException if the user input does not conform the expected format
      */
-    public Command parseCommand(String userInput) throws ParseException {
+    public Command parseCommand(String userInput, Status status) throws ParseException {
         final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
         if (!matcher.matches()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));

--- a/src/main/java/seedu/address/logic/parser/MainCatalogueParser.java
+++ b/src/main/java/seedu/address/logic/parser/MainCatalogueParser.java
@@ -18,6 +18,7 @@ import seedu.address.logic.commands.LeaveCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.StartCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.exceptions.InvalidScopeException;
 import seedu.address.model.project.Status;
 
 /**
@@ -73,6 +74,10 @@ public class MainCatalogueParser {
                 case HelpCommand.COMMAND_WORD:
                     return new HelpCommand();
 
+                case StartCommand.COMMAND_WORD:
+                case LeaveCommand.COMMAND_WORD:
+                    throw new InvalidScopeException(Status.PROJECT, Status.CATALOGUE);
+
                 default:
                     throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
             }
@@ -83,6 +88,20 @@ public class MainCatalogueParser {
 
                 case LeaveCommand.COMMAND_WORD:
                     return new LeaveCommand();
+
+                case ExitCommand.COMMAND_WORD:
+                    return new ExitCommand();
+
+                case HelpCommand.COMMAND_WORD:
+                    return new HelpCommand();
+
+                case AddCommand.COMMAND_WORD:
+                case EditCommand.COMMAND_WORD:
+                case DeleteCommand.COMMAND_WORD:
+                case ClearCommand.COMMAND_WORD:
+                case FindCommand.COMMAND_WORD:
+                case ListCommand.COMMAND_WORD:
+                    throw new InvalidScopeException(Status.CATALOGUE, Status.PROJECT);
 
                 default:
                     throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/MainCatalogueParser.java
+++ b/src/main/java/seedu/address/logic/parser/MainCatalogueParser.java
@@ -46,39 +46,48 @@ public class MainCatalogueParser {
 
         final String commandWord = matcher.group("commandWord");
         final String arguments = matcher.group("arguments");
-        switch (commandWord) {
+        if (status == Status.CATALOGUE) {
+            switch (commandWord) {
 
-        case AddCommand.COMMAND_WORD:
-            return new AddCommandParser().parse(arguments);
+                case AddCommand.COMMAND_WORD:
+                    return new AddCommandParser().parse(arguments);
 
-        case EditCommand.COMMAND_WORD:
-            return new EditCommandParser().parse(arguments);
+                case EditCommand.COMMAND_WORD:
+                    return new EditCommandParser().parse(arguments);
 
-        case DeleteCommand.COMMAND_WORD:
-            return new DeleteCommandParser().parse(arguments);
+                case DeleteCommand.COMMAND_WORD:
+                    return new DeleteCommandParser().parse(arguments);
 
-        case ClearCommand.COMMAND_WORD:
-            return new ClearCommand();
+                case ClearCommand.COMMAND_WORD:
+                    return new ClearCommand();
 
-        case FindCommand.COMMAND_WORD:
-            return new FindCommandParser().parse(arguments);
+                case FindCommand.COMMAND_WORD:
+                    return new FindCommandParser().parse(arguments);
 
-        case ListCommand.COMMAND_WORD:
-            return new ListCommand();
+                case ListCommand.COMMAND_WORD:
+                    return new ListCommand();
 
-        case ExitCommand.COMMAND_WORD:
-            return new ExitCommand();
+                case ExitCommand.COMMAND_WORD:
+                    return new ExitCommand();
 
-        case HelpCommand.COMMAND_WORD:
-            return new HelpCommand();
+                case HelpCommand.COMMAND_WORD:
+                    return new HelpCommand();
 
-        case StartCommand.COMMAND_WORD:
-            return new StartCommandParser().parse(arguments);
+                default:
+                    throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
+            }
+        } else if (status == Status.PROJECT) {
+            switch (commandWord) {
+                case StartCommand.COMMAND_WORD:
+                    return new StartCommandParser().parse(arguments);
 
-        case LeaveCommand.COMMAND_WORD:
-            return new LeaveCommand();
+                case LeaveCommand.COMMAND_WORD:
+                    return new LeaveCommand();
 
-        default:
+                default:
+                    throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
+            }
+        } else {
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
         }
     }

--- a/src/test/java/seedu/address/logic/parser/MainCatalogueParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/MainCatalogueParserTest.java
@@ -25,6 +25,7 @@ import seedu.address.logic.commands.LeaveCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.StartCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.exceptions.InvalidScopeException;
 import seedu.address.model.project.NameContainsKeywordsPredicate;
 import seedu.address.model.project.Project;
 import seedu.address.model.project.Status;
@@ -70,6 +71,8 @@ public class MainCatalogueParserTest {
     public void parseCommand_exit() throws Exception {
         assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD, Status.CATALOGUE) instanceof ExitCommand);
         assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD + " 3", Status.CATALOGUE) instanceof ExitCommand);
+        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD, Status.PROJECT) instanceof ExitCommand);
+        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD + " 3", Status.PROJECT) instanceof ExitCommand);
     }
 
     @Test
@@ -84,6 +87,8 @@ public class MainCatalogueParserTest {
     public void parseCommand_help() throws Exception {
         assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD, Status.CATALOGUE) instanceof HelpCommand);
         assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3", Status.CATALOGUE) instanceof HelpCommand);
+        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD, Status.PROJECT) instanceof HelpCommand);
+        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3", Status.PROJECT) instanceof HelpCommand);
     }
 
     @Test
@@ -115,5 +120,66 @@ public class MainCatalogueParserTest {
     public void parseCommand_unknownCommand_throwsParseException() {
         assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () -> parser.parseCommand("unknownCommand",
                 Status.CATALOGUE));
+    }
+
+    @Test
+    public void parseCommand_invalidScope_throwsInvalidScopeException() {
+        try {
+            Project project = new ProjectBuilder().build();
+            parser.parseCommand(ProjectUtil.getAddCommand(project), Status.PROJECT);
+        } catch (Exception e) {
+            assertEquals(new InvalidScopeException(Status.CATALOGUE, Status.PROJECT), e);
+        }
+
+        try {
+            parser.parseCommand(ClearCommand.COMMAND_WORD, Status.PROJECT);
+        } catch (Exception e) {
+            assertEquals(new InvalidScopeException(Status.CATALOGUE, Status.PROJECT), e);
+        }
+
+        try {
+            parser.parseCommand(
+                    DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PROJECT.getOneBased(), Status.PROJECT);
+        } catch (Exception e) {
+            assertEquals(new InvalidScopeException(Status.CATALOGUE, Status.PROJECT), e);
+        }
+
+        try {
+            Project project = new ProjectBuilder().build();
+            EditProjectDescriptor descriptor = new EditProjectDescriptorBuilder(project).build();
+            parser.parseCommand(EditCommand.COMMAND_WORD + " " + INDEX_FIRST_PROJECT.getOneBased()
+                            + " " + ProjectUtil.getEditProjectDescriptorDetails(descriptor),
+                    Status.PROJECT);
+        } catch (Exception e) {
+            assertEquals(new InvalidScopeException(Status.CATALOGUE, Status.PROJECT), e);
+        }
+
+        try {
+            List<String> keywords = Arrays.asList("foo", "bar", "baz");
+            parser.parseCommand(
+                    FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")),
+                    Status.CATALOGUE);
+        } catch (Exception e) {
+            assertEquals(new InvalidScopeException(Status.CATALOGUE, Status.PROJECT), e);
+        }
+
+        try {
+            parser.parseCommand(ListCommand.COMMAND_WORD, Status.PROJECT);
+        } catch (Exception e) {
+            assertEquals(new InvalidScopeException(Status.CATALOGUE, Status.PROJECT), e);
+        }
+
+        try {
+            parser.parseCommand(
+                    StartCommand.COMMAND_WORD + " " + INDEX_FIRST_PROJECT.getOneBased(), Status.CATALOGUE);
+        } catch (Exception e) {
+            assertEquals(new InvalidScopeException(Status.PROJECT, Status.CATALOGUE), e);
+        }
+
+        try {
+            parser.parseCommand(LeaveCommand.COMMAND_WORD, Status.CATALOGUE);
+        } catch (Exception e) {
+            assertEquals(new InvalidScopeException(Status.PROJECT, Status.CATALOGUE), e);
+        }
     }
 }

--- a/src/test/java/seedu/address/logic/parser/MainCatalogueParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/MainCatalogueParserTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import seedu.address.model.project.Status;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PROJECT;
 
@@ -38,20 +39,20 @@ public class MainCatalogueParserTest {
     @Test
     public void parseCommand_add() throws Exception {
         Project project = new ProjectBuilder().build();
-        AddCommand command = (AddCommand) parser.parseCommand(ProjectUtil.getAddCommand(project));
+        AddCommand command = (AddCommand) parser.parseCommand(ProjectUtil.getAddCommand(project), Status.CATALOGUE);
         assertEquals(new AddCommand(project), command);
     }
 
     @Test
     public void parseCommand_clear() throws Exception {
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD) instanceof ClearCommand);
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3") instanceof ClearCommand);
+        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD, Status.CATALOGUE) instanceof ClearCommand);
+        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3", Status.CATALOGUE) instanceof ClearCommand);
     }
 
     @Test
     public void parseCommand_delete() throws Exception {
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
-                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PROJECT.getOneBased());
+                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PROJECT.getOneBased(), Status.CATALOGUE);
         assertEquals(new DeleteCommand(INDEX_FIRST_PROJECT), command);
     }
 
@@ -60,57 +61,57 @@ public class MainCatalogueParserTest {
         Project project = new ProjectBuilder().build();
         EditProjectDescriptor descriptor = new EditProjectDescriptorBuilder(project).build();
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
-                + INDEX_FIRST_PROJECT.getOneBased() + " " + ProjectUtil.getEditProjectDescriptorDetails(descriptor));
+                + INDEX_FIRST_PROJECT.getOneBased() + " " + ProjectUtil.getEditProjectDescriptorDetails(descriptor), Status.CATALOGUE);
         assertEquals(new EditCommand(INDEX_FIRST_PROJECT, descriptor), command);
     }
 
     @Test
     public void parseCommand_exit() throws Exception {
-        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD) instanceof ExitCommand);
-        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD + " 3") instanceof ExitCommand);
+        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD, Status.CATALOGUE) instanceof ExitCommand);
+        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD + " 3", Status.CATALOGUE) instanceof ExitCommand);
     }
 
     @Test
     public void parseCommand_find() throws Exception {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         FindCommand command = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
+                FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")), Status.CATALOGUE);
         assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
     }
 
     @Test
     public void parseCommand_help() throws Exception {
-        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD) instanceof HelpCommand);
-        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3") instanceof HelpCommand);
+        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD, Status.CATALOGUE) instanceof HelpCommand);
+        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3", Status.CATALOGUE) instanceof HelpCommand);
     }
 
     @Test
     public void parseCommand_list() throws Exception {
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD, Status.CATALOGUE) instanceof ListCommand);
+        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3", Status.CATALOGUE) instanceof ListCommand);
     }
 
     @Test
     public void parseCommand_start() throws Exception {
         StartCommand command = (StartCommand) parser.parseCommand(
-                StartCommand.COMMAND_WORD + " " + INDEX_FIRST_PROJECT.getOneBased());
+                StartCommand.COMMAND_WORD + " " + INDEX_FIRST_PROJECT.getOneBased(), Status.CATALOGUE);
         assertEquals(new StartCommand(INDEX_FIRST_PROJECT), command);
     }
 
     @Test
     public void parseCommand_leave() throws Exception {
-        assertTrue(parser.parseCommand(LeaveCommand.COMMAND_WORD) instanceof LeaveCommand);
-        assertTrue(parser.parseCommand(LeaveCommand.COMMAND_WORD + " 3") instanceof LeaveCommand);
+        assertTrue(parser.parseCommand(LeaveCommand.COMMAND_WORD, Status.CATALOGUE) instanceof LeaveCommand);
+        assertTrue(parser.parseCommand(LeaveCommand.COMMAND_WORD + " 3", Status.CATALOGUE) instanceof LeaveCommand);
     }
 
     @Test
     public void parseCommand_unrecognisedInput_throwsParseException() {
         assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), ()
-            -> parser.parseCommand(""));
+            -> parser.parseCommand("", Status.CATALOGUE));
     }
 
     @Test
     public void parseCommand_unknownCommand_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () -> parser.parseCommand("unknownCommand"));
+        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () -> parser.parseCommand("unknownCommand", Status.CATALOGUE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/MainCatalogueParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/MainCatalogueParserTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
-import seedu.address.model.project.Status;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PROJECT;
 
@@ -28,6 +27,7 @@ import seedu.address.logic.commands.StartCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.project.NameContainsKeywordsPredicate;
 import seedu.address.model.project.Project;
+import seedu.address.model.project.Status;
 import seedu.address.testutil.EditProjectDescriptorBuilder;
 import seedu.address.testutil.ProjectBuilder;
 import seedu.address.testutil.ProjectUtil;
@@ -61,7 +61,8 @@ public class MainCatalogueParserTest {
         Project project = new ProjectBuilder().build();
         EditProjectDescriptor descriptor = new EditProjectDescriptorBuilder(project).build();
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
-                + INDEX_FIRST_PROJECT.getOneBased() + " " + ProjectUtil.getEditProjectDescriptorDetails(descriptor), Status.CATALOGUE);
+                + INDEX_FIRST_PROJECT.getOneBased() + " " + ProjectUtil.getEditProjectDescriptorDetails(descriptor),
+                Status.CATALOGUE);
         assertEquals(new EditCommand(INDEX_FIRST_PROJECT, descriptor), command);
     }
 
@@ -94,14 +95,14 @@ public class MainCatalogueParserTest {
     @Test
     public void parseCommand_start() throws Exception {
         StartCommand command = (StartCommand) parser.parseCommand(
-                StartCommand.COMMAND_WORD + " " + INDEX_FIRST_PROJECT.getOneBased(), Status.CATALOGUE);
+                StartCommand.COMMAND_WORD + " " + INDEX_FIRST_PROJECT.getOneBased(), Status.PROJECT);
         assertEquals(new StartCommand(INDEX_FIRST_PROJECT), command);
     }
 
     @Test
     public void parseCommand_leave() throws Exception {
-        assertTrue(parser.parseCommand(LeaveCommand.COMMAND_WORD, Status.CATALOGUE) instanceof LeaveCommand);
-        assertTrue(parser.parseCommand(LeaveCommand.COMMAND_WORD + " 3", Status.CATALOGUE) instanceof LeaveCommand);
+        assertTrue(parser.parseCommand(LeaveCommand.COMMAND_WORD, Status.PROJECT) instanceof LeaveCommand);
+        assertTrue(parser.parseCommand(LeaveCommand.COMMAND_WORD + " 3", Status.PROJECT) instanceof LeaveCommand);
     }
 
     @Test
@@ -112,6 +113,7 @@ public class MainCatalogueParserTest {
 
     @Test
     public void parseCommand_unknownCommand_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () -> parser.parseCommand("unknownCommand", Status.CATALOGUE));
+        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () -> parser.parseCommand("unknownCommand",
+                Status.CATALOGUE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/MainCatalogueParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/MainCatalogueParserTest.java
@@ -100,7 +100,7 @@ public class MainCatalogueParserTest {
     @Test
     public void parseCommand_start() throws Exception {
         StartCommand command = (StartCommand) parser.parseCommand(
-                StartCommand.COMMAND_WORD + " " + INDEX_FIRST_PROJECT.getOneBased(), Status.PROJECT);
+                StartCommand.COMMAND_WORD + " " + INDEX_FIRST_PROJECT.getOneBased(), Status.CATALOGUE);
         assertEquals(new StartCommand(INDEX_FIRST_PROJECT), command);
     }
 
@@ -171,9 +171,9 @@ public class MainCatalogueParserTest {
 
         try {
             parser.parseCommand(
-                    StartCommand.COMMAND_WORD + " " + INDEX_FIRST_PROJECT.getOneBased(), Status.CATALOGUE);
+                    StartCommand.COMMAND_WORD + " " + INDEX_FIRST_PROJECT.getOneBased(), Status.PROJECT);
         } catch (Exception e) {
-            assertEquals(new InvalidScopeException(Status.PROJECT, Status.CATALOGUE), e);
+            assertEquals(new InvalidScopeException(Status.CATALOGUE, Status.PROJECT), e);
         }
 
         try {


### PR DESCRIPTION
I didn't extend the original `Parser` because the original code is not very easy to extend. Instead, I just add some code in `MainCatalogueParser` to differentiate scope before parsing, which I think is easier.